### PR TITLE
Don't delete file contents on error

### DIFF
--- a/ansible.el
+++ b/ansible.el
@@ -127,9 +127,10 @@
     nil))
 
 (defun ansible::vault-buffer (mode)
-  (let ((str (buffer-substring-no-properties (point-min) (point-max))))
+  (let* ((input (buffer-substring-no-properties (point-min) (point-max)))
+         (output (ansible::vault mode input)))
     (delete-region (point-min) (point-max))
-    (insert (ansible::vault mode str))))
+    (insert output)))
 
 (defun ansible::get-string-from-file (file-path)
   "Return FILE-PATH's file content."


### PR DESCRIPTION
When running `ansible::{en,de}crypt-buffer` if the vault password is
wrong, an error is raised and the contents of the buffer are deleted.

This is annoying to me, since I have to deal with various files with
different vault passwords.

This PR fixes this behavior by trying to decrypt the buffer *before*
deleting its contents.