### PR TITLE
Add `ansible::auto-decrypt-encrypt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,17 @@ or hook
 
 ### Ansible Vault support
 
-Set up a password in ~/vault_pass
+Set up a password in `ansible::vault-password-file`: (default value:
+"~/vault_pass")
+
+    (setq ansible::vault-password-file "path/to/pwd/file")
 
 Bind keys:
 
-  (global-set-key (kbd "C-c b") 'ansible::decrypt-buffer)
-  (global-set-key (kbd "C-c g") 'ansible::encrypt-buffer)
+    (global-set-key (kbd "C-c b") 'ansible::decrypt-buffer)
+    (global-set-key (kbd "C-c g") 'ansible::encrypt-buffer)
+
+You can also set automatic {en,de}cryption by adding
+`ansible::auto-decrypt-encrypt` to `ansible-hook`:
+
+    (add-hook 'ansible-hook 'ansible::auto-decrypt-encrypt)


### PR DESCRIPTION
`ansible::auto-decrypt-encrypt` function is meant to be added to
`ansible-hook`.

This function will try to decrypt the visited file. If the file was
successfully decrypted, `ansible::encrypt-buffer` will be added to the
local `before-save-hook`, and `ansible::decrypt-buffer` will be added to
the local `after-save-hook`. That means that the visited file will be
encrypted just before being saved to disk, and will be decrypted right
afterwards, leading to an experience close to how easypg works.