### PR TITLE
 Fixes #11 Encrypted file falsely marked as modified on auto-decryption

### DIFF
--- a/ansible.el
+++ b/ansible.el
@@ -328,7 +328,9 @@
 
 (defun ansible::decrypt-buffer ()
   (interactive)
-  (ansible::vault-buffer "decrypt"))
+  (ansible::vault-buffer "decrypt")
+  ;; force buffer to be marked as unmodified
+  (set-buffer-modified-p nil))
 
 (defun ansible::encrypt-buffer ()
   (interactive)


### PR DESCRIPTION
Hi,

This PR fixes the issue where encrypted files are falsely marked as modified on auto-decryption.

Cheers,
syl20bnr