### PR TITLE
some fixes

### DIFF
--- a/ansible.el
+++ b/ansible.el
@@ -27,10 +27,6 @@
 ;; desired.  And put the following expression into your ~/.emacs.
 ;;
 ;; (require 'ansible)
-;;
-;; If you use default key map, Put the following expression into your ~/.emacs.
-;;
-;; (ansible::set-default-keymap)
 
 ;;; Commentary:
 

--- a/ansible.el
+++ b/ansible.el
@@ -99,8 +99,8 @@
   (concat
      "^ *-? "
      (regexp-opt
-      '("hosts" "vars" "vars_prompt" "vars_files" "role" "include" "strategy"
-	"roles" "tasks" "handlers" "pre_tasks" "post_tasks" "gather_facts" "connection" ) t)
+      '("hosts" "vars" "vars_prompt" "vars_files" "role"  "include" "strategy"
+	"roles" "tasks" "handlers" "pre_tasks" "post_tasks" ) t)
      ":")
   "Special keywords used to identify toplevel information in a playbook")
 
@@ -225,8 +225,8 @@
       '("with_items" "with_dict" "with_nested" "with_first_found" "with_fileglob"
 	"with_together" "with_subelements" "with_sequence" "with_random_choice" "until"
 	"retries" "delay" "with_lines" "with_indexed_items" "with_ini" "with_flattened"
-	"with_inventory_hostnames" "when" "notify" "register" "tags"
-	"tags" "become" "become_user" "args" "local_action" "delegate_to") t)
+	"with_inventory_hostnames" "when" "notify" "register" "tags" "gather_facts"
+	"connection" "tags" "become" "become_user" "args" "local_action" "delegate_to") t)
      ":")
   "Ansible keywords used with tasks")
 


### PR DESCRIPTION
1. my #16 I did the changes I want to revert back. It also assures `gather_facts` is specified once, but not twice in different lists.

2. removing the reference to `(ansible::set-default-keymap)`, I can find no such function in the file or in my installation (from melpa).