### PR TITLE
ansible 2.4 introduces `import_tasks` and `include_tasks`

### DIFF
--- a/ansible.el
+++ b/ansible.el
@@ -95,7 +95,7 @@
   (concat
      "^ *-? "
      (regexp-opt
-      '("hosts" "vars" "vars_prompt" "vars_files" "role" "include"
+      '("hosts" "vars" "vars_prompt" "vars_files" "role" "include" "include_tasks"
         "roles" "tasks" "import_tasks" "handlers" "pre_tasks" "post_tasks" ) t)
      ":")
   "Special keywords used to identify toplevel information in a playbook.")

--- a/ansible.el
+++ b/ansible.el
@@ -96,7 +96,7 @@
      "^ *-? "
      (regexp-opt
       '("hosts" "vars" "vars_prompt" "vars_files" "role" "include"
-        "roles" "tasks" "handlers" "pre_tasks" "post_tasks" ) t)
+        "roles" "tasks" "import_tasks" "handlers" "pre_tasks" "post_tasks" ) t)
      ":")
   "Special keywords used to identify toplevel information in a playbook.")
 


### PR DESCRIPTION
it should be highlighted same as `include` as this actually replaces it in some use cases