### PR TITLE
Added 'environment' section keyword

### DIFF
--- a/ansible.el
+++ b/ansible.el
@@ -93,11 +93,11 @@
 
 (defconst ansible::section-keywords-regex
   (concat
-     "^ *-? "
-     (regexp-opt
-      '("hosts" "vars" "vars_prompt" "vars_files" "role" "include" "include_tasks"
-        "roles" "tasks" "import_tasks" "handlers" "pre_tasks" "post_tasks" ) t)
-     ":")
+   "^ *-? "
+   (regexp-opt
+    '("hosts" "vars" "vars_prompt" "vars_files" "role" "include" "include_tasks"
+      "roles" "tasks" "import_tasks" "handlers" "pre_tasks" "post_tasks" "environment" ) t)
+   ":")
   "Special keywords used to identify toplevel information in a playbook.")
 
 (defconst ansible::task-keywords-regex


### PR DESCRIPTION
Just added the missing `environment` section keyword.

This is not a new one, it is in fact present since [since ansible version 1.1](http://docs.ansible.com/ansible/latest/playbooks_environment.html).

Awesome project btw. With it and [glynnforrest/mmm-jinja2](https://github.com/glynnforrest/mmm-jinja2) editing ansible config under emacs is a plain joy :beers: