### PR TITLE
update the 'cl require so it isn't called on emacs >= 26.

### DIFF
--- a/ansible.el
+++ b/ansible.el
@@ -51,7 +51,14 @@
 ;;require
 (require 's)
 (require 'f)
-(eval-when-compile (require 'cl))
+
+;; the 'cl package has been deprecated in favour of 'cl-lib. Load 'cl
+;; on emacs < 26, otherwise load 'cl-lib.
+(eval-when-compile
+  (if (version< emacs-version "26")
+      (require 'cl)
+    (require 'cl-lib)))
+
 (require 'easy-mmode)
 
 (defgroup ansible nil


### PR DESCRIPTION
the 'cl package has been superseded by 'cl-lib since emacs 26. Requiring it throws a warning in emacs 27 and beyond.