### PR TITLE
Fix syntax highlight of comments

### DIFF
--- a/ansible.el
+++ b/ansible.el
@@ -244,7 +244,7 @@
      (3 font-lock-builtin-face t))
     (,ansible-section-keywords-regex    (1 ansible-section-face t))
     (,ansible-task-keywords-regex       (1 font-lock-keyword-face t))
-    ("^ *- \\(name\\):\\(.*\\)"
+    ("^ *- \\(name\\):\\([^#\n]*\\)"
      (1 font-lock-builtin-face t)
      (2 ansible-task-label-face t))
     (,ansible-keywords-regex            (1 font-lock-builtin-face t)))


### PR DESCRIPTION
Comments are not correctly highlighted in lines beginning with "name:". This PR try to fix the problem.

Without the PR:
![ansible-comment-before](https://user-images.githubusercontent.com/17704127/152041820-8462383c-2f89-455a-8325-062ef4ace665.png)

With the PR:
![ansible-comment-after](https://user-images.githubusercontent.com/17704127/152041835-aee47cdd-e17a-4020-972d-fb1b986fc6ae.png)
