### PR TITLE
Fix output parsing for other languages

### DIFF
--- a/ansible.el
+++ b/ansible.el
@@ -397,7 +397,7 @@ Also, automatically encrypts the file before saving the buffer."
 (add-to-list 'compilation-error-regexp-alist
              'ansible)
 (add-to-list 'compilation-error-regexp-alist-alist
-             '(ansible "^\\(.*?\\):\\([0-9]+\\)" 1 2)
+             '(ansible "^\\(.*?\\.yml\\):\\([0-9]+\\)" 1 2)
              )
 
 ; Replace make -k with ansible-lint, with an UTF-8 locale to avoid crashes

--- a/ansible.el
+++ b/ansible.el
@@ -392,13 +392,6 @@ Also, automatically encrypts the file before saving the buffer."
       (add-to-list 'ac-user-dictionary-files (f-join dict-dir "ansible") t))))
 
 ;;;###ansible-lint
-; Compile regex for ansible-lint
-(require 'compile)
-(add-to-list 'compilation-error-regexp-alist
-             'ansible)
-(add-to-list 'compilation-error-regexp-alist-alist
-             '(ansible "^\\(.*?\\.yml\\):\\([0-9]+\\)" 1 2)
-             )
 
 ; Replace make -k with ansible-lint, with an UTF-8 locale to avoid crashes
 (defun ansible-lint-errors ()


### PR DESCRIPTION
Following https://github.com/k1LoW/emacs-ansible/issues/49

After careful investigation: the way `compilation-error-regexp-alist-alist` works is that all possible regexps for every languages are added to this list without any further per-compiler filtering.

I could try to work around this by only matching `.yml` files (which I do in the first commit) but that could still interfere with other use of yaml files.

But it seems the `compilation-error-regexp-alist-alist` has changed since the time I wrote this piece of code, as file:line matching pretty much works without the need to add anything to it (even though the regexp includes the space following the line number, but that's just a detail and that's not breaking) (tested on emacs 29.3).

In the absence of a more satisfying solution, I just outright removed the regexp, as file:line get matched anyway (this may break in the future, though. In this case, revert second commit).